### PR TITLE
Modify the jquery binding, and add a mode for bar graph

### DIFF
--- a/jquery.flot.multihighlight.js
+++ b/jquery.flot.multihighlight.js
@@ -4,6 +4,7 @@
 		multihighlight: {
 			mode: null,	// null, x or y.
 			linkedPlots: null,	// null or array of plots.
+			hoverMode: null // null, point or bar.
 		}
 	};
 	
@@ -39,9 +40,11 @@
 
 						if (j != 0 && serie.data[j] !=null) {
 							var highlighted = j-1;
-							// Checking which one is closer.
-							if (axisPosition-serie.data[j-1][dataIndex] > Math.abs(axisPosition-serie.data[j][dataIndex])) {
-								highlighted = j;
+							// Checking which one is closer if it is not a bar graph.
+							if (plotToHighlight.getOptions().multihighlight.hoverMode !== 'bar') {
+								if (axisPosition-serie.data[j-1][dataIndex] > Math.abs(axisPosition-serie.data[j][dataIndex])) {
+									highlighted = j;
+								}
 							}
 
 							plotToHighlight.highlight(i, highlighted);

--- a/jquery.flot.multihighlight.js
+++ b/jquery.flot.multihighlight.js
@@ -1,4 +1,4 @@
-$(function() {
+(function($) {
 	
 	var options = {
 		multihighlight: {
@@ -88,4 +88,4 @@ $(function() {
 		name: 'multihighlight',
 		version: '1.0'
 	});
-});
+})(jQuery);

--- a/jquery.flot.multihighlight.js
+++ b/jquery.flot.multihighlight.js
@@ -32,16 +32,17 @@
 					var highlightedItems = new Array();
 					$.each(plotToHighlight.getData(), function(i, serie) {
 						var j;
+
 						for (j = 0; j < serie.data.length; j++) {
 							if (serie.data[j] == null || serie.data[j][dataIndex] > axisPosition) {
 								break;
 							}
 						}
 
-						if (j != 0 && serie.data[j] !=null) {
+						if (j != 0) {
 							var highlighted = j-1;
 							// Checking which one is closer if it is not a bar graph.
-							if (plotToHighlight.getOptions().multihighlight.hoverMode !== 'bar') {
+							if (plotToHighlight.getOptions().multihighlight.hoverMode !== 'bar' && serie.data[j] != null) {
 								if (axisPosition-serie.data[j-1][dataIndex] > Math.abs(axisPosition-serie.data[j][dataIndex])) {
 									highlighted = j;
 								}


### PR DESCRIPTION
I found I cannot use this plugin in my jQuery 1.7.1 with flot 0.7, and I found the plugin won't load without this mod.

use http://flot.googlecode.com/svn/trunk/PLUGINS.txt as reference.

and I was using this on bar graph which causes its hover range not right. this pull request add bar graph mode, too.
